### PR TITLE
Fix: extended order expired

### DIFF
--- a/exchanges/extended.py
+++ b/exchanges/extended.py
@@ -239,6 +239,7 @@ class ExtendedClient(BaseExchangeClient):
                     side=side,
                     time_in_force=TimeInForce.GTT,
                     post_only=True,  # Ensure MAKER orders
+                    expire_time = utc_now() + timedelta(days=1), # SDK 1 hour default
                 )
 
                 if not order_result or not order_result.data or order_result.status != 'OK':
@@ -350,7 +351,8 @@ class ExtendedClient(BaseExchangeClient):
                     price=rounded_price,
                     side=order_side,
                     time_in_force=TimeInForce.GTT,
-                    post_only=True  # Ensure MAKER orders
+                    post_only=True,  # Ensure MAKER orders
+                    expire_time = utc_now() + timedelta(days=90), # SDK 1 hour default
                 )
 
                 if not order_result or not order_result.data or order_result.status != 'OK':

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -286,7 +286,8 @@ class TradingBot:
                     current_order_status = self.exchange_client.current_order.status
                 else:
                     order_info = await self.exchange_client.get_order_info(order_id)
-                    current_order_status = order_info.status
+                    if order_info is not None:
+                        current_order_status = order_info.status
                 new_order_price = await self.exchange_client.get_order_price(self.config.direction)
 
             self.order_canceled_event.clear()


### PR DESCRIPTION
1. Fix order expiration issue for the extended exchange: Since the extended SDK defaults to a 1-hour expiration for limit orders, we set a longer expiration time (1 day for open orders and 90 days for close orders).
2. Fix potential None return in get_order_info: Improved the robustness of the get_order_info function to handle cases where it might return None.