### PR TITLE
Refactor dotenv loading and add env file argument

### DIFF
--- a/hedge/hedge_mode_bp.py
+++ b/hedge/hedge_mode_bp.py
@@ -21,10 +21,6 @@ from exchanges.backpack import BackpackClient
 import websockets
 from datetime import datetime
 import pytz
-import dotenv
-
-dotenv.load_dotenv()
-
 
 class Config:
     """Simple config class to wrap dictionary for Backpack client."""

--- a/hedge/hedge_mode_ext.py
+++ b/hedge/hedge_mode_ext.py
@@ -21,9 +21,6 @@ from exchanges.extended import ExtendedClient
 import websockets
 from datetime import datetime
 import pytz
-import dotenv
-
-dotenv.load_dotenv()
 
 
 class Config:

--- a/hedge_mode.py
+++ b/hedge_mode.py
@@ -21,7 +21,8 @@ import asyncio
 import sys
 import argparse
 from decimal import Decimal
-
+from pathlib import Path
+import dotenv
 
 def parse_arguments():
     """Parse command line arguments."""
@@ -45,6 +46,8 @@ Examples:
                         help='Number of iterations to run')
     parser.add_argument('--fill-timeout', type=int, default=5,
                         help='Timeout in seconds for maker order fills (default: 5)')
+    parser.add_argument('--env-file', type=str, default=".env",
+                        help=".env file path (default: .env)")
     
     return parser.parse_args()
 
@@ -77,6 +80,12 @@ def get_hedge_bot_class(exchange):
 async def main():
     """Main entry point that creates and runs the appropriate hedge bot."""
     args = parse_arguments()
+
+    env_path = Path(args.env_file)
+    if not env_path.exists():
+        print(f"Env file not find: {env_path.resolve()}")
+        sys.exit(1)
+    dotenv.load_dotenv(args.env_file)
     
     # Validate exchange
     validate_exchange(args.exchange)


### PR DESCRIPTION
Moved dotenv loading from hedge_mode_bp.py and hedge_mode_ext.py into hedge_mode.py. Added --env-file argument to specify the .env file path, and now check for its existence before loading. This centralizes environment variable management and improves configurability.