### PR TITLE
feat: Ethereal exchange support and its subaccount bind scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,3 +196,14 @@ cython_debug/
 
 # pyenv settings
 .python-version
+
+# sh script
+start.sh
+stop.sh
+start*.sh
+stop*.sh
+
+# Claude
+.claude/
+CLAUDE.md
+claude-docs/

--- a/.gitignore
+++ b/.gitignore
@@ -196,14 +196,3 @@ cython_debug/
 
 # pyenv settings
 .python-version
-
-# sh script
-start.sh
-stop.sh
-start*.sh
-stop*.sh
-
-# Claude
-.claude/
-CLAUDE.md
-claude-docs/

--- a/env_example.txt
+++ b/env_example.txt
@@ -53,6 +53,14 @@ APEX_OMNI_KEY_SEED=your_apex_omni_key_seed
 NADO_PRIVATE_KEY=your_nado_private_key_here
 NADO_MODE=MAINNET  # or DEVNET
 
+# Ethereal Configuration
+ETHEREAL_BASE_URL=https://api.ethereal.trade
+ETHEREAL_RPC_URL=https://rpc.ethereal.trade
+ETHEREAL_CHAIN_ID=42161
+ETHEREAL_PRIVATE_KEY=your_private_key # required for signing orders
+ETHEREAL_SUBACCOUNT_ID=your_subaccount_id
+ETHEREAL_ACCOUNT_NAME=primary
+
 # Notification (optional)
 # guide: https://www.feishu.cn/hc/zh-CN/articles/185289387886-%E6%B6%88%E6%81%AF%E5%8A%A9%E6%89%8B-%E6%9C%BA%E5%99%A8%E4%BA%BA
 LARK_TOKEN=

--- a/env_example.txt
+++ b/env_example.txt
@@ -56,7 +56,7 @@ NADO_MODE=MAINNET  # or DEVNET
 # Ethereal Configuration
 ETHEREAL_BASE_URL=https://api.ethereal.trade
 ETHEREAL_RPC_URL=https://rpc.ethereal.trade
-ETHEREAL_CHAIN_ID=42161
+ETHEREAL_CHAIN_ID=5064014
 ETHEREAL_PRIVATE_KEY=your_private_key # required for signing orders
 ETHEREAL_SUBACCOUNT_ID=your_subaccount_id
 ETHEREAL_ACCOUNT_NAME=primary

--- a/exchanges/ethereal.py
+++ b/exchanges/ethereal.py
@@ -1,0 +1,670 @@
+"""
+Ethereal exchange client skeleton built on the official ethereal-sdk.
+"""
+
+import os
+import asyncio
+from decimal import Decimal
+from typing import Any, Dict, List, Optional, Tuple
+from uuid import UUID
+
+from .base import BaseExchangeClient, OrderResult, OrderInfo
+from helpers.logger import TradingLogger
+from ethereal import AsyncRESTClient, AsyncWSClient
+
+
+class EtherealClient(BaseExchangeClient):
+    """
+    Ethereal exchange client wired to ethereal-sdk.
+    """
+
+    def __init__(self, config: Dict[str, Any]):
+        """Initialize Ethereal client with environment-driven defaults."""
+        # REST + chain config (all optional; defaults follow the SDK docs)
+        self.base_url = os.getenv("ETHEREAL_BASE_URL", "https://api.ethereal.trade")
+        self.rpc_url = os.getenv("ETHEREAL_RPC_URL", "https://rpc.ethereal.trade")
+        self.private_key = os.getenv("ETHEREAL_PRIVATE_KEY")  # required for signing
+        self.chain_id = int(os.getenv("ETHEREAL_CHAIN_ID", "42161"))
+        self.ws_url = os.getenv("ETHEREAL_WS_URL", "wss://ws.ethereal.trade")
+
+        # Account / trading context
+        self.subaccount_id = os.getenv("ETHEREAL_SUBACCOUNT_ID")
+        self.account_name = os.getenv("ETHEREAL_ACCOUNT_NAME", "primary")
+        self.subaccount_hex = os.getenv("ETHEREAL_SUBACCOUNT")
+        if not self.subaccount_hex and self.account_name:
+            try:
+                self.subaccount_hex = self._encode_subaccount_name(self.account_name)
+            except Exception:
+                self.subaccount_hex = None
+        self._warned_missing_subaccount = False
+
+        # Clients are created lazily in connect()
+        self._rest_client: Optional["AsyncRESTClient"] = None
+        self._ws_client: Optional["AsyncWSClient"] = None
+        self._ws_task: Optional[asyncio.Task] = None
+        self._order_update_handler = None
+        self.current_order: Optional[OrderInfo] = None
+        self._product_cache: Dict[str, Any] = {}
+        self._ws_stop = asyncio.Event()
+        self._poll_task: Optional[asyncio.Task] = None
+        self._ws_connected = False
+
+        self.logger = TradingLogger(
+            exchange="ethereal",
+            ticker=getattr(config, "ticker", ""),
+            log_to_console=False
+        )
+
+        # Base init last: sets self.config and runs _validate_config
+        super().__init__(config)
+
+    def _validate_config(self) -> None:
+        """Validate Ethereal configuration."""
+        # Ticker is required; contract_id is optional (will default to ticker if missing).
+        if not getattr(self.config, "ticker", None):
+            raise ValueError("Missing required config field: ticker")
+        if not getattr(self.config, "contract_id", None):
+            self.config.contract_id = self.config.ticker
+
+        # Signing key is optional for read-only calls, but required for trading.
+        if not getattr(self, "private_key", None):
+            self.logger.log("ETHEREAL_PRIVATE_KEY not set; trading calls will fail.", "WARN")
+
+    def _build_rest_config(self) -> Dict[str, Any]:
+        """
+        Assemble the config dict expected by AsyncRESTClient.create().
+
+        Example from the SDK docs:
+            await AsyncRESTClient.create({
+                "base_url": "https://api.ethereal.trade",
+                "chain_config": {
+                    "rpc_url": "https://rpc.ethereal.trade",
+                    "private_key": "your_private_key",
+                }
+            })
+        """
+        config: Dict[str, Any] = {
+            "base_url": self.base_url,
+            "chain_config": {
+                "rpc_url": self.rpc_url,
+                "chain_id": self.chain_id,
+            },
+        }
+        if self.private_key:
+            config["chain_config"]["private_key"] = self.private_key
+        return config
+
+    async def _ensure_rest_client(self) -> None:
+        """Create the AsyncRESTClient on-demand."""
+        if self._rest_client is not None:
+            return
+
+        if AsyncRESTClient is None:
+            raise ImportError("ethereal-sdk not installed or not available in this environment")
+
+        self._rest_client = await AsyncRESTClient.create(self._build_rest_config())
+
+    async def _ensure_products(self) -> Dict[str, Any]:
+        """Cache products by ticker for quick lookups."""
+        if self._product_cache:
+            return self._product_cache
+        await self._ensure_rest_client()
+        products = await self._rest_client.products_by_ticker()
+        # store uppercase keys
+        self._product_cache = {k.upper(): v for k, v in products.items()}
+        return self._product_cache
+
+    async def _start_ws(self) -> None:
+        """Start AsyncWSClient and subscribe to order stream."""
+        if AsyncWSClient is None:
+            raise ImportError("ethereal-sdk websocket client not available")
+
+        self._ws_client = AsyncWSClient({"base_url": self.ws_url})
+        # Register callbacks for likely order event types
+        for key in ("Order", "OrderState", "OrderUpdate"):
+            self._ws_client.callbacks.setdefault(key, []).append(self._handle_ws_message)
+
+        await self._ws_client.open(namespaces=["/v1/stream"])
+        self._ws_connected = True
+
+        product = await self._get_product_by_ticker(self.config.contract_id or self.config.ticker)
+        product_id = getattr(product, "id", None) if product else None
+
+        # Best-effort subscribe; failures fall back to polling.
+        try:
+            await self._ws_client.subscribe(
+                stream_type="Order",
+                product_id=product_id,
+                subaccount_id=self.subaccount_id,
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            self.logger.log(f"[ethereal] WS subscribe Order failed: {exc}", "WARNING")
+
+    async def _get_product_by_ticker(self, ticker: Any) -> Optional[Any]:
+        products = await self._ensure_products()
+        if ticker is None:
+            return None
+
+        # Normalize ticker/id to string for comparison
+        if isinstance(ticker, UUID):
+            ticker_str = str(ticker)
+        else:
+            ticker_str = str(ticker)
+
+        # First try matching by product id
+        for item in products.values():
+            if str(getattr(item, "id", "")) == ticker_str:
+                return item
+
+        # Then try ticker-based lookup (expects e.g. BTCUSD)
+        key = ticker_str.upper()
+        if key.endswith("USD"):
+            prod = products.get(key)
+        else:
+            prod = products.get(f"{key}USD")
+        if prod:
+            return prod
+
+        return None
+
+    def _encode_subaccount_name(self, name: str) -> str:
+        """Encode subaccount name to bytes32 hex (0x...)."""
+        if not name:
+            raise ValueError("Subaccount name is empty")
+        b = name.encode("utf-8")
+        if len(b) > 32:
+            raise ValueError("Subaccount name too long for bytes32")
+        return "0x" + b.ljust(32, b"\x00").hex()
+
+    async def _handle_ws_message(self, data: Dict[str, Any]):
+        """Bridge WS order events to the trading bot handler."""
+        if not self._order_update_handler:
+            return
+
+        try:
+            order_id = data.get("orderId") or data.get("id")
+            status = data.get("status") or data.get("state")
+            side_val = data.get("side")
+            side = "buy" if side_val in (0, "buy", "BUY") else "sell"
+            filled_size = data.get("filledSize") or data.get("filled") or 0
+            size = data.get("size") or data.get("quantity") or 0
+            price = data.get("price") or data.get("orderPrice") or 0
+
+            self._order_update_handler(
+                {
+                    "contract_id": self.config.contract_id,
+                    "order_id": str(order_id),
+                    "status": status or "",
+                    "side": side,
+                    "order_type": "OPEN",
+                    "filled_size": str(filled_size),
+                    "size": str(size),
+                    "price": str(price),
+                }
+            )
+        except Exception:
+            pass
+
+    async def _poll_orders_loop(self):
+        """Simple polling loop to emit order updates to the handler."""
+        last_status: Dict[str, str] = {}
+        while not self._ws_stop.is_set():
+            try:
+                active_orders = await self.get_active_orders(self.config.contract_id)
+                for order in active_orders:
+                    prev = last_status.get(order.order_id)
+                    if prev != order.status:
+                        last_status[order.order_id] = order.status
+                        if self._order_update_handler:
+                            try:
+                                self._order_update_handler(
+                                    {
+                                        "contract_id": self.config.contract_id,
+                                        "order_id": order.order_id,
+                                        "status": order.status,
+                                        "side": order.side,
+                                        "order_type": "OPEN",
+                                        "filled_size": str(order.filled_size),
+                                        "size": str(order.size),
+                                        "price": str(order.price),
+                                    }
+                                )
+                            except Exception:
+                                pass
+            except Exception as exc:
+                self.logger.log(f"[ethereal] order polling error: {exc}", "WARNING")
+
+            try:
+                await asyncio.wait_for(self._ws_stop.wait(), timeout=2.0)
+            except asyncio.TimeoutError:
+                continue
+
+    async def connect(self) -> None:
+        """
+        Initialize REST client and prepare WS hooks.
+
+        The ethereal-sdk exposes AsyncRESTClient (for trading / queries) and
+        AsyncWSClient (for streaming order updates). Only the REST client is
+        instantiated here; the WS wiring is left as a placeholder until the
+        desired subscriptions are finalized.
+        """
+        await self._ensure_rest_client()
+        # TODO: initialize AsyncWSClient and subscribe to order/position streams.
+        try:
+            await self._ensure_products()
+        except Exception as exc:
+            self.logger.log(f"Failed to preload products: {exc}", "WARNING")
+
+        # Try to open WS for order updates; fall back to polling if it fails or no handler.
+        if self._order_update_handler:
+            try:
+                await self._start_ws()
+            except Exception as exc:
+                self.logger.log(f"WS connect failed, falling back to polling: {exc}", "WARNING")
+                if self._poll_task is None or self._poll_task.done():
+                    self._ws_stop.clear()
+                    self._poll_task = asyncio.create_task(self._poll_orders_loop())
+        else:
+            if self._poll_task is None or self._poll_task.done():
+                self._ws_stop.clear()
+                self._poll_task = asyncio.create_task(self._poll_orders_loop())
+
+    async def disconnect(self) -> None:
+        """Tear down REST/WS clients."""
+        try:
+            self._ws_stop.set()
+            if self._poll_task and not self._poll_task.done():
+                await self._poll_task
+        except Exception:
+            pass
+
+        try:
+            if self._ws_client:
+                await self._ws_client.close()
+        except Exception as exc:
+            self.logger.log(f"Error closing Ethereal WS client: {exc}", "ERROR")
+        self._ws_connected = False
+        self._ws_client = None
+
+        try:
+            if self._rest_client and hasattr(self._rest_client, "close"):
+                await self._rest_client.close()
+        except Exception as exc:
+            self.logger.log(f"Error closing Ethereal REST client: {exc}", "ERROR")
+
+        self._ws_client = None
+        self._rest_client = None
+
+    def get_exchange_name(self) -> str:
+        """Get the exchange name."""
+        return "ethereal"
+
+    def setup_order_update_handler(self, handler) -> None:
+        """
+        Register a callback for order updates.
+
+        AsyncWSClient supports a callbacks dict keyed by stream type
+        (see docs for subscribe/unsubscribe). Once WS wiring is added,
+        self._order_update_handler will be invoked from the WS message handler.
+        """
+        self._order_update_handler = handler
+
+    async def place_open_order(self, contract_id: str, quantity: Decimal, direction: str) -> OrderResult:
+        """
+        Place an open order using AsyncRESTClient.create_order().
+
+        TODO: Map local direction/ticker to Ethereal order params (side, order_type,
+        price/stop fields, subaccount, client_order_id, etc.).
+        """
+        try:
+            await self._ensure_rest_client()
+        except ImportError as exc:
+            return OrderResult(success=False, error_message=str(exc))
+
+        if not self.private_key or not self.subaccount_id:
+            return OrderResult(
+                success=False,
+                error_message="Missing ETHEREAL_PRIVATE_KEY or ETHEREAL_SUBACCOUNT_ID"
+            )
+
+        product = await self._get_product_by_ticker(contract_id or self.config.contract_id)
+        if not product:
+            return OrderResult(success=False, error_message="Product not found for ticker")
+
+        best_bid, best_ask = await self._fetch_bbo(product.id)
+        if best_bid == 0 and best_ask == 0:
+            return OrderResult(success=False, error_message="Failed to fetch order book")
+
+        if direction == "buy":
+            price = best_ask
+            side = 0
+        else:
+            price = best_bid
+            side = 1
+
+        price = self.round_to_tick(Decimal(str(price)))
+
+        try:
+            order = await self._rest_client.create_order(
+                order_type="LIMIT",
+                quantity=float(quantity),
+                side=side,
+                price=float(price),
+                product_id=product.id,
+                subaccount=self.subaccount_hex,
+                time_in_force="GTD",
+                post_only=True,
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            return OrderResult(success=False, error_message=str(exc))
+
+        order_id = getattr(order, "id", None) or (order.get("id") if isinstance(order, dict) else None)
+        return OrderResult(
+            success=bool(order_id),
+            order_id=str(order_id) if order_id else None,
+            side="buy" if side == 0 else "sell",
+            size=Decimal(str(quantity)),
+            price=Decimal(str(price)),
+            status=getattr(order, "status", "OPEN") if order_id else "FAILED",
+        )
+
+    async def place_close_order(self, contract_id: str, quantity: Decimal, price: Decimal, side: str) -> OrderResult:
+        """
+        Place a close/reduce order using AsyncRESTClient.create_order().
+
+        TODO: wire reduce_only/close flags once the trade flow is defined.
+        """
+        try:
+            await self._ensure_rest_client()
+        except ImportError as exc:
+            return OrderResult(success=False, error_message=str(exc))
+
+        if not self.private_key or not self.subaccount_id:
+            return OrderResult(
+                success=False,
+                error_message="Missing ETHEREAL_PRIVATE_KEY or ETHEREAL_SUBACCOUNT_ID"
+            )
+
+        product = await self._get_product_by_ticker(contract_id or self.config.contract_id)
+        if not product:
+            return OrderResult(success=False, error_message="Product not found for ticker")
+
+        side_val = 0 if side.lower() == "buy" else 1
+        price = self.round_to_tick(Decimal(str(price)))
+        try:
+            order = await self._rest_client.create_order(
+                order_type="LIMIT",
+                quantity=float(quantity),
+                side=side_val,
+                price=float(price),
+                product_id=product.id,
+                subaccount=self.subaccount_hex,
+                time_in_force="GTD",
+                reduce_only=True,
+                post_only=True,
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            return OrderResult(success=False, error_message=str(exc))
+
+        order_id = getattr(order, "id", None) or (order.get("id") if isinstance(order, dict) else None)
+        return OrderResult(
+            success=bool(order_id),
+            order_id=str(order_id) if order_id else None,
+            side="buy" if side_val == 0 else "sell",
+            size=Decimal(str(quantity)),
+            price=Decimal(str(price)),
+            status=getattr(order, "status", "OPEN") if order_id else "FAILED",
+        )
+
+    async def cancel_order(self, order_id: str) -> OrderResult:
+        """
+        Cancel an order.
+
+        The SDK exposes AsyncRESTClient.cancel_orders([...]) / cancel_all_orders().
+        """
+        try:
+            await self._ensure_rest_client()
+        except ImportError as exc:
+            return OrderResult(success=False, error_message=str(exc))
+
+        if not self.private_key or not self.subaccount_id:
+            return OrderResult(
+                success=False,
+                error_message="Missing ETHEREAL_PRIVATE_KEY or ETHEREAL_SUBACCOUNT_ID"
+            )
+
+        try:
+            await self._rest_client.cancel_orders(
+                order_ids=[order_id],
+                sender=self._rest_client.chain.address if hasattr(self._rest_client, "chain") else None,
+                subaccount=self.subaccount_hex,
+            )
+            return OrderResult(success=True, order_id=order_id)
+        except Exception as exc:  # pylint: disable=broad-except
+            return OrderResult(success=False, error_message=str(exc))
+
+    async def get_order_info(self, order_id: str) -> Optional[OrderInfo]:
+        """
+        Fetch order details via AsyncRESTClient.get_order().
+        """
+        try:
+            await self._ensure_rest_client()
+        except ImportError:
+            return None
+
+        try:
+            order = await self._rest_client.get_order(id=order_id)
+        except Exception:
+            order = None
+
+        if not order:
+            return None
+
+        side = getattr(order, "side", None)
+        size = getattr(order, "quantity", None)
+        price = getattr(order, "price", None)
+        status = str(getattr(order, "status", "UNKNOWN"))
+        filled = getattr(order, "filled", None)
+        remaining = getattr(order, "available_quantity", None)
+
+        return OrderInfo(
+            order_id=order_id,
+            side="buy" if side in (0, "buy", "BUY") else "sell",
+            size=Decimal(str(size or "0")),
+            price=Decimal(str(price or "0")),
+            status=status,
+            filled_size=Decimal(str(filled or "0")),
+            remaining_size=Decimal(str(remaining or "0")),
+        )
+
+    async def get_active_orders(self, contract_id: str) -> List[OrderInfo]:
+        """
+        List open orders for the configured contract.
+
+        The SDK provides AsyncRESTClient.list_orders() / list_trades().
+        """
+        try:
+            await self._ensure_rest_client()
+        except ImportError:
+            return []
+
+        if not self.subaccount_id:
+            self.logger.log("ETHEREAL_SUBACCOUNT_ID not set; cannot fetch active orders.", "WARNING")
+            return []
+
+        product = await self._get_product_by_ticker(contract_id)
+        product_id = getattr(product, "id", None) if product else None
+
+        try:
+            orders = await self._rest_client.list_orders(
+                subaccount_id=self.subaccount_id,
+                product_ids=[product_id] if product_id else None,
+            )
+        except Exception:
+            orders = []
+
+        order_infos: List[OrderInfo] = []
+        for order in orders or []:
+            try:
+                status_raw = getattr(order, "status", "")
+                status_str = str(status_raw).lower()
+                # Skip non-active (canceled/filled) orders
+                if "cancel" in status_str or "filled" in status_str:
+                    continue
+
+                order_infos.append(
+                    OrderInfo(
+                        order_id=str(getattr(order, "id", "")),
+                        side="buy" if getattr(order, "side", 0) in (0, "buy", "BUY") else "sell",
+                        size=Decimal(str(getattr(order, "quantity", "0"))),
+                        price=Decimal(str(getattr(order, "price", "0"))),
+                        status=str(status_raw),
+                        filled_size=Decimal(str(getattr(order, "filled", "0"))),
+                        remaining_size=Decimal(str(getattr(order, "available_quantity", getattr(order, "quantity", "0")))),
+                    )
+                )
+            except Exception:
+                continue
+
+        return order_infos
+
+    async def get_order_price(self, direction: str) -> Decimal:
+        """
+        Provide a placeholder price used by TradingBot when pacing orders.
+
+        Uses current BBO to place near-touching maker orders.
+        """
+        product = await self._get_product_by_ticker(self.config.contract_id or self.config.ticker)
+        if not product:
+            raise ValueError("Product not found for ticker")
+        best_bid, best_ask = await self._fetch_bbo(product.id)
+        if direction == "buy":
+            price = best_ask
+        else:
+            price = best_bid
+        return self.round_to_tick(Decimal(str(price)))
+
+    async def fetch_bbo_prices(self, contract_id: str) -> Tuple[Decimal, Decimal]:
+        """Expose BBO for TradingBot stop/price checks."""
+        product = await self._get_product_by_ticker(contract_id or self.config.contract_id)
+        if not product:
+            return Decimal(0), Decimal(0)
+        return await self._fetch_bbo(product.id)
+
+    async def _fetch_bbo(self, product_id: Any) -> Tuple[Decimal, Decimal]:
+        """Fetch best bid/ask via get_market_liquidity."""
+        try:
+            liquidity = await self._rest_client.get_market_liquidity(product_id=product_id)
+        except Exception as exc:
+            self.logger.log(f"[ethereal] get_market_liquidity failed: {exc}", "WARNING")
+            return Decimal(0), Decimal(0)
+
+        bids = getattr(liquidity, "bids", None) or []
+        asks = getattr(liquidity, "asks", None) or []
+        best_bid = Decimal(str(bids[0][0])) if bids else Decimal(0)
+        best_ask = Decimal(str(asks[0][0])) if asks else Decimal(0)
+        return best_bid, best_ask
+
+    async def list_positions(self, subaccount_id: Optional[str] = None) -> List[Any]:
+        """
+        Fetch positions for a subaccount using any available SDK method.
+
+        - subaccount_id: overrides the default from ENV if provided.
+        Returns a list (can be empty).
+        """
+        try:
+            await self._ensure_rest_client()
+        except ImportError as exc:
+            self.logger.log(f"ethereal-sdk not installed: {exc}", "ERROR")
+            return []
+
+        rest = self._rest_client
+
+        sid = subaccount_id or self.subaccount_id
+        if not sid:
+            if not self._warned_missing_subaccount:
+                self.logger.log("ETHEREAL_SUBACCOUNT_ID not set; cannot fetch positions.", "WARN")
+                self._warned_missing_subaccount = True
+            return []
+
+        if hasattr(rest, "list_positions"):
+            try:
+                resp = await rest.list_positions(subaccount_id=sid)
+                return self._extract_positions(resp)
+            except Exception as exc:  # pylint: disable=broad-except
+                self.logger.log(f"[ethereal] list_positions failed: {exc}", "WARNING")
+
+        self.logger.log("No position endpoint available on Ethereal client", "ERROR")
+        return []
+
+    def _extract_positions(self, resp: Any) -> List[Any]:
+        """Normalize common Ethereal SDK response shapes to a list."""
+        if resp is None:
+            return []
+        if isinstance(resp, list):
+            return resp
+        if isinstance(resp, dict):
+            for key in ("positions", "data", "result", "results"):
+                if key in resp and isinstance(resp[key], list):
+                    return resp[key]
+        if hasattr(resp, "positions"):
+            maybe = getattr(resp, "positions")
+            if isinstance(maybe, list):
+                return maybe
+        return []
+
+    async def get_account_positions(self) -> Decimal:
+        """
+        Retrieve current position size for the configured contract.
+
+        The SDK provides AsyncRESTClient.list_positions() and get_position().
+        """
+        await self._ensure_rest_client()
+        positions = await self.list_positions()
+        target_id = str(self.config.contract_id)
+        for pos in positions:
+            product_id = (
+                pos.get("product_id")
+                if isinstance(pos, dict)
+                else getattr(pos, "product_id", None)
+            )
+            if not product_id:
+                product_id = (
+                    pos.get("productId")
+                    if isinstance(pos, dict)
+                    else getattr(pos, "productId", None)
+                )
+
+            if product_id and str(product_id) == target_id:
+                size_val = (
+                    pos.get("size")
+                    if isinstance(pos, dict)
+                    else getattr(pos, "size", None)
+                )
+                try:
+                    return abs(Decimal(str(size_val or "0")))
+                except Exception:
+                    return Decimal(0)
+
+        return Decimal(0)
+
+    async def get_contract_attributes(self) -> Tuple[str, Decimal]:
+        """
+        Retrieve contract identifier and tick size for a ticker.
+
+        Uses products_by_ticker; falls back to ticker if lookup fails.
+        """
+        ticker = self.config.ticker
+        if not ticker:
+            raise ValueError("Ticker is empty")
+
+        product = await self._get_product_by_ticker(ticker)
+        if product:
+            self.config.contract_id = getattr(product, "id", ticker.upper())
+            tick_size_val = getattr(product, "tick_size", None)
+            self.config.tick_size = Decimal(str(tick_size_val)) if tick_size_val else Decimal(0)
+        else:
+            self.config.contract_id = ticker.upper()
+            self.config.tick_size = Decimal(0)
+
+        return self.config.contract_id, self.config.tick_size

--- a/exchanges/ethereal.py
+++ b/exchanges/ethereal.py
@@ -163,6 +163,17 @@ class EtherealClient(BaseExchangeClient):
 
         return None
 
+    async def get_ticker_by_product_id(self, product_id: Any) -> Optional[str]:
+        """Look up ticker string from a product id."""
+        if product_id is None:
+            return None
+        products = await self._ensure_products()
+        pid = str(product_id)
+        for ticker_key, prod in products.items():
+            if str(getattr(prod, "id", "")) == pid:
+                return ticker_key
+        return None
+
     def _product_id_to_str(self, product: Any) -> Optional[str]:
         """Extract product id as string."""
         if not product:
@@ -634,6 +645,7 @@ class EtherealClient(BaseExchangeClient):
         self.logger.log("No position endpoint available on Ethereal client", "ERROR")
         return []
 
+    
     def _extract_positions(self, resp: Any) -> List[Any]:
         """Normalize common Ethereal SDK response shapes to a list."""
         if resp is None:

--- a/exchanges/factory.py
+++ b/exchanges/factory.py
@@ -19,6 +19,7 @@ class ExchangeFactory:
         'extended': 'exchanges.extended.ExtendedClient',
         'apex': 'exchanges.apex.ApexClient',
         'nado': 'exchanges.nado.NadoClient',
+        'ethereal': 'exchanges.ethereal.EtherealClient',
     }
 
     @classmethod

--- a/exchanges/grvt.py
+++ b/exchanges/grvt.py
@@ -284,7 +284,7 @@ class GrvtClient(BaseExchangeClient):
                 order_status = order_info.status
 
         if order_status == 'PENDING':
-            raise Exception('Paradex Server Error: Order not processed after 10 seconds')
+            raise Exception('GRVT Server Error: Order not processed after 10 seconds')
         else:
             return order_info
 

--- a/helpers/ethereal/README.md
+++ b/helpers/ethereal/README.md
@@ -1,0 +1,47 @@
+# Ethereal Subaccount 绑定工具
+
+## 使用方法
+
+本目录包含两个辅助工具，用于完成 Ethereal “linked signer” 绑定所需的双重签名流程：
+
+1. `subaccount_eip712.html`
+
+   - 作用：用浏览器 + MetaMask 生成主钱包的 EIP-712 `signature`（授权把 linked signer 绑定到子账户），并生成需要的请求体/命令。
+   - 用法：
+     - 用浏览器打开该文件，连接主钱包。
+     - 填入 `signer`（待绑定的 linked signer 地址），保持 `subaccount label` 默认 `primary`。
+     - 点击 “Sign Typed Data” 生成 `signature`，页面会自动生成 `signerSignature` 的 Python 命令。
+     - 将 linked signer 私钥放在 `.env` 的 `ETHEREAL_PRIVATE_KEY` 后，运行生成的命令，得到 `signerSignature`，粘贴回页面。
+     - 点击 “Link Subaccount” 发送 `/v1/linked-signer/link` 请求，状态区会显示成功/失败。
+   - 安全性：主钱包签名在浏览器/钱包内完成，避免以明文暴露主钱包私钥；官方 UI 暂未提供该绑定流程，因此用本地页面完成交互。
+
+2. `sign_linked_signer.py`
+   - 作用：用 linked signer 私钥生成 `signerSignature`（证明你控制待绑定的 signer 地址）。
+   - 前置：在 `.env` 配置 `ETHEREAL_PRIVATE_KEY` 为 linked signer 私钥。
+   - 用法示例（参数来自页面提示）：
+
+    ```bash
+    python helpers/ethereal/sign_linked_signer.py \
+       --sender <主钱包地址> \
+       --subaccount <bytes32 子账户名> \
+       --nonce <页面给出的 nonce> \
+       --signed-at <页面给出的 signedAt>
+    ```
+
+    仅输出签名 hex，将其填入 HTML 的 `signerSignature` 输入框即可。
+
+## 为什么需要用工具绑定子账户？
+
+- Ethereal 官方界面暂未提供子账户绑定 linked signer 的前端；需要用户自己完成 EIP-712 授权。
+- 主钱包私钥不应离开钱包/浏览器环境，HTML + MetaMask 可避免在本地脚本中明文处理主钱包私钥。
+- linked signer 私钥只用于生成 `signerSignature`，可放在 `.env` 后由 Python 脚本离线签名。
+
+## 可能遇到的问题
+
+1. subaccount label 目前只支持 'primary' 的 bytes32 编码，使用其他编码会报错（暂时不知道原因）
+2. subaccount address 如果之前添加过，然后 revoke 了，不能再次添加，需要换一个新的钱包来作为 subaccount 绑定
+3. subaccount 不需要 gas ，临时生成一个即可（例如 `cast wallet new`）
+
+---
+
+请在安全环境中使用以上工具，并确认网络指向官方 API（默认 `https://api.ethereal.trade`）。\*\*\*

--- a/helpers/ethereal/sign_linked_signer.py
+++ b/helpers/ethereal/sign_linked_signer.py
@@ -1,0 +1,118 @@
+"""
+Utility to produce signerSignature for Ethereal linked signer flow.
+
+Minimal use:
+    python sign_linked_signer.py \
+        --sender 0xYourEOA \
+        --subaccount 0xYourBytes32Label
+
+Other fields auto-generated:
+- signer = address derived from ETHEREAL_PRIVATE_KEY (read from .env)
+- nonce   = time.time_ns()
+- signedAt= current seconds
+- chainId / verifyingContract / domain name+version use Ethereal defaults (override flags if needed)
+
+Install requirement if missing: pip install eth_account python-dotenv
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from typing import Any, Dict
+
+from dotenv import load_dotenv
+
+from eth_account import Account
+from eth_account.messages import encode_typed_data
+from eth_utils import to_checksum_address
+
+
+TYPES = {
+    "EIP712Domain": [
+        {"name": "name", "type": "string"},
+        {"name": "version", "type": "string"},
+        {"name": "chainId", "type": "uint256"},
+        {"name": "verifyingContract", "type": "address"},
+    ],
+    "LinkSigner": [
+        {"name": "sender", "type": "address"},
+        {"name": "signer", "type": "address"},
+        {"name": "subaccount", "type": "bytes32"},
+        {"name": "nonce", "type": "uint64"},
+        {"name": "signedAt", "type": "uint64"},
+    ],
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Create signerSignature for Ethereal linked signer")
+    parser.add_argument("--sender", required=True, help="EOA that owns the subaccount")
+    parser.add_argument("--subaccount", required=True, help="bytes32 subaccount label (0x...)")
+    parser.add_argument("--nonce", help="uint64 nonce as string; default: time.time_ns()")
+    parser.add_argument("--signed-at", dest="signed_at", type=int, help="Signed at timestamp (seconds); default: now")
+    parser.add_argument("--chain-id", dest="chain_id", type=int, default=5064014, help="Chain ID (default: 5064014)")
+    parser.add_argument(
+        "--verifying-contract",
+        dest="verifying_contract",
+        default="0xb3cdc82035c495c484c9ff11ed5f3ff6d342e3cc",
+        help="Domain verifyingContract (default: Ethereal mainnet)",
+    )
+    parser.add_argument("--name", default="Ethereal", help="Domain name (default: Ethereal)")
+    parser.add_argument("--version", default="1", help="Domain version (default: 1)")
+    return parser.parse_args()
+
+
+def build_typed_data(args: argparse.Namespace) -> Dict[str, Any]:
+    domain = {
+        "name": args.name,
+        "version": args.version,
+        "chainId": args.chain_id,
+        "verifyingContract": args.verifying_contract,
+    }
+    message = {
+        "sender": args.sender,
+        "signer": args.signer,
+        "subaccount": args.subaccount,
+        "nonce": str(args.nonce),
+        "signedAt": int(args.signed_at),
+    }
+    return {
+        "types": TYPES,
+        "primaryType": "LinkSigner",
+        "domain": domain,
+        "message": message,
+    }
+
+
+def main():
+    load_dotenv()
+    args = parse_args()
+
+    priv_key = os.getenv("ETHEREAL_PRIVATE_KEY")
+    if not priv_key:
+        sys.stderr.write("ETHEREAL_PRIVATE_KEY not set in environment or .env\n")
+        sys.exit(1)
+
+    account = Account.from_key(priv_key)
+
+    # Autofill signer, nonce, signedAt if missing
+    args.signer = to_checksum_address(account.address)
+    args.sender = to_checksum_address(args.sender)
+    args.subaccount = args.subaccount
+    if not args.nonce:
+        args.nonce = str(time.time_ns())
+    if not args.signed_at:
+        args.signed_at = int(time.time())
+
+    typed_data = build_typed_data(args)
+    signable = encode_typed_data(full_message=typed_data)
+    signed = account.sign_message(signable)
+
+    # Output only the signature hex (signerSignature)
+    sys.stdout.write("\n0x" + signed.signature.hex() + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/helpers/ethereal/subaccount_eip712.html
+++ b/helpers/ethereal/subaccount_eip712.html
@@ -1,0 +1,363 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Ethereal Linked Signer EIP-712</title>
+  <style>
+    body { font-family: Arial, sans-serif; max-width: 900px; margin: 24px auto; padding: 0 16px; color: #111; background: #f7f7fb; }
+    h1 { margin-bottom: 4px; }
+    small { color: #555; }
+    fieldset { border: 1px solid #ccc; padding: 12px 16px; margin-bottom: 12px; background: #fff; }
+    label { display: block; font-weight: 600; margin-top: 10px; }
+    input { width: 100%; padding: 8px; margin-top: 4px; box-sizing: border-box; }
+    button { padding: 10px 14px; margin-top: 12px; cursor: pointer; }
+    code, pre { background: #f0f0f3; padding: 6px; display: block; white-space: pre-wrap; word-break: break-all; }
+    .row { display: flex; gap: 12px; }
+    .row > div { flex: 1; }
+    #status { margin-top: 8px; color: #0a5; font-weight: 600; }
+    #error { margin-top: 8px; color: #c00; font-weight: 600; }
+  </style>
+  <script src="https://cdn.jsdelivr.net/npm/ethers@5.7.2/dist/ethers.umd.min.js"></script>
+</head>
+<body>
+  <h1>Ethereal Linked Signer EIP-712</h1>
+  <small>Connect MetaMask, fill signer + subaccount info, then sign typed data for /linked-signer/link.</small>
+
+  <fieldset>
+    <button id="connect">Connect MetaMask</button>
+    <div id="status">Not connected</div>
+    <div id="error"></div>
+  </fieldset>
+
+  <fieldset>
+    <legend>Message</legend>
+    <label>sender (auto from connected wallet)</label>
+    <input id="sender" readonly placeholder="Connect wallet first">
+
+    <label>subaccount address (linked signer)</label>
+    <input id="signer" placeholder="0x...">
+
+    <label>subaccount label (默认 primary，最好不要修改)</label>
+    <input id="subaccountLabel" value="primary" readonly>
+
+    <div class="row">
+      <div>
+        <label>signedAt (seconds)</label>
+        <input id="signedAt" type="number">
+      </div>
+      <div>
+        <label>nonce (uint64 as string, e.g. nanos)</label>
+        <input id="nonce">
+      </div>
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <legend>Action</legend>
+    <button id="sign">Sign Typed Data (eth_signTypedData_v4)</button>
+    <label>Signature</label>
+    <code id="signature"></code>
+  </fieldset>
+
+  <fieldset>
+    <legend>Send to Ethereal API</legend>
+    <label>API Base URL</label>
+    <input id="apiBase" value="https://api.ethereal.trade">
+
+    <label>subaccountId (UUID from query API)</label>
+    <input id="subaccountId">
+
+    <label>生成 signerSignature 的命令（linked signer 私钥本地运行）</label>
+    <pre id="cliSnippet"></pre>
+
+    <label>signerSignature (填入上面命令的输出，自动验证)</label>
+    <input id="signerSignature" placeholder="0x...">
+    <div id="signerSigStatus"></div>
+
+    <button id="send">Link Subaccount</button>
+    <div id="apiStatus"></div>
+  </fieldset>
+
+  <script>
+    const statusEl = document.getElementById("status");
+    const errorEl = document.getElementById("error");
+    const senderEl = document.getElementById("sender");
+    const signerEl = document.getElementById("signer");
+    const subLabelEl = document.getElementById("subaccountLabel");
+    const signedAtEl = document.getElementById("signedAt");
+    const nonceEl = document.getElementById("nonce");
+    const sigEl = document.getElementById("signature");
+    const cliSnippetEl = document.getElementById("cliSnippet");
+    const signerSigStatusEl = document.getElementById("signerSigStatus");
+    const apiStatusEl = document.getElementById("apiStatus");
+    let lastTypedMessage = null;
+    let lastTypedDomain = null;
+    let lastSignature = "";
+    let signerSigValid = false;
+    const domainDefaults = {
+      name: "Ethereal",
+      version: "1",
+      chainId: 5064014,
+      verifyingContract: "0xb3cdc82035c495c484c9ff11ed5f3ff6d342e3cc",
+    };
+
+    function showError(msg) {
+      errorEl.textContent = msg || "";
+    }
+
+    function toBytes32Padded(label) {
+      const encoder = new TextEncoder(); // UTF-8
+      const bytes = encoder.encode(label);
+
+      if (bytes.length > 32) {
+        throw new Error("String too long for bytes32");
+      }
+
+      const padded = new Uint8Array(32);
+      padded.set(bytes);
+
+      return "0x" + [...padded]
+        .map(b => b.toString(16).padStart(2, "0"))
+        .join("");
+    }
+
+    function autoFillTime() {
+      const nowSec = Math.floor(Date.now() / 1000);
+      const nowNanos = BigInt(Date.now()) * 1000000n + BigInt(Math.floor(Math.random() * 1_000_000));
+      signedAtEl.value = nowSec.toString();
+      nonceEl.value = nowNanos.toString();
+    }
+
+    async function connectWallet() {
+      showError("");
+      if (!window.ethereum) {
+        showError("MetaMask not detected.");
+        return;
+      }
+      const accounts = await window.ethereum.request({ method: "eth_requestAccounts" });
+      const account = window.ethers && window.ethers.utils ? window.ethers.utils.getAddress(accounts[0]) : accounts[0];
+      senderEl.value = account;
+      statusEl.textContent = `Connected: ${account}`;
+    }
+
+    function buildTypedData() {
+      const domain = { ...domainDefaults };
+
+      const subLabel = (subLabelEl.value || "primary").trim();
+      if (!subLabel) throw new Error("Subaccount label is required");
+      const subaccount = toBytes32Padded(subLabel);
+
+      const signerAddrInput = (signerEl.value || "").trim();
+      const signerAddr = window.ethers && window.ethers.utils ? window.ethers.utils.getAddress(signerAddrInput) : signerAddrInput;
+      if (!signerAddr) throw new Error("Signer address is required");
+      if (!senderEl.value) throw new Error("Connect wallet to populate sender");
+
+      const signedAtVal = signedAtEl.value ? Math.floor(Number(signedAtEl.value)) : 0;
+      const nonceVal = nonceEl.value ? nonceEl.value.toString() : "0";
+
+      const message = {
+        sender: senderEl.value,
+        signer: signerAddr,
+        subaccount,
+        nonce: nonceVal,
+        signedAt: signedAtVal
+      };
+
+      const types = {
+        EIP712Domain: [
+          { name: "name", type: "string" },
+          { name: "version", type: "string" },
+          { name: "chainId", type: "uint256" },
+          { name: "verifyingContract", type: "address" },
+        ],
+        LinkSigner: [
+          { name: "sender", type: "address" },
+          { name: "signer", type: "address" },
+          { name: "subaccount", type: "bytes32" },
+          { name: "nonce", type: "uint64" },
+          { name: "signedAt", type: "uint64" },
+        ],
+      };
+
+      const typedData = {
+        types,
+        primaryType: "LinkSigner",
+        domain,
+        message,
+      };
+      return typedData;
+    }
+
+    async function signTypedData() {
+      showError("");
+      sigEl.textContent = "";
+      autoFillTime(); // auto-fill time and nonce on sign
+      if (!window.ethereum) {
+        showError("MetaMask not detected.");
+        return;
+      }
+      if (!senderEl.value) {
+        showError("Connect wallet first.");
+        return;
+      }
+      try {
+        const typedData = buildTypedData();
+        const params = [senderEl.value, JSON.stringify(typedData)];
+        const signature = await window.ethereum.request({
+          method: "eth_signTypedData_v4",
+          params,
+        });
+        sigEl.textContent = signature;
+        lastTypedMessage = typedData.message;
+        lastTypedDomain = typedData.domain;
+        lastSignature = signature;
+        buildApiPayloadPreview(signature, typedData.message);
+        await autoFetchSubaccountId();
+      } catch (err) {
+        showError(err.message || String(err));
+      }
+    }
+
+    function buildApiPayloadPreview(signature, messageOverride) {
+      const msg = messageOverride || lastTypedMessage || buildTypedData().message;
+      const payload = {
+        signature,
+        signerSignature: document.getElementById("signerSignature").value || undefined,
+        data: {
+          subaccountId: document.getElementById("subaccountId").value || undefined,
+          sender: msg.sender,
+          subaccount: msg.subaccount,
+          signer: msg.signer,
+          nonce: msg.nonce,
+          signedAt: msg.signedAt,
+        },
+      };
+      // Remove undefined fields for clarity
+      const cleaned = JSON.parse(JSON.stringify(payload, (k, v) => v === undefined ? undefined : v));
+      renderCliSnippet(cleaned);
+      return cleaned;
+    }
+
+    function renderCliSnippet(payload) {
+      const { data, signature, signerSignature } = payload;
+      if (!data) return;
+      const lines = [
+        "python ./helpers/ethereal/sign_linked_signer.py \\",
+        `  --sender ${data.sender || "<sender>"} \\`,
+        `  --subaccount ${data.subaccount || "<bytes32_subaccount>"} \\`,
+        `  --nonce ${data.nonce || "<nonce>"} \\`,
+        `  --signed-at ${data.signedAt || "<signedAt>"}`
+      ];
+      cliSnippetEl.textContent = lines.join("\n");
+    }
+
+    async function verifySignerSignature() {
+      signerSigStatusEl.textContent = "";
+      signerSigStatusEl.style.color = "#111";
+      signerSigValid = false;
+      try {
+        if (!window.ethers || !window.ethers.utils) {
+          throw new Error("ethers.js not loaded");
+        }
+        const sig = document.getElementById("signerSignature").value.trim();
+        if (!sig) throw new Error("signerSignature is empty");
+        const typed = lastTypedMessage
+          ? { domain: lastTypedDomain || buildTypedData().domain, message: lastTypedMessage }
+          : buildTypedData();
+        const { domain, message } = typed;
+        const typesNoDomain = {
+          LinkSigner: [
+            { name: "sender", type: "address" },
+            { name: "signer", type: "address" },
+            { name: "subaccount", type: "bytes32" },
+            { name: "nonce", type: "uint64" },
+            { name: "signedAt", type: "uint64" },
+          ],
+        };
+        const recovered = window.ethers.utils.verifyTypedData(domain, typesNoDomain, message, sig);
+        if (recovered.toLowerCase() === message.signer.toLowerCase()) {
+          signerSigStatusEl.textContent = `signerSignature valid (recovered ${recovered})`;
+          signerSigStatusEl.style.color = "#0a5";
+          signerSigValid = true;
+        } else {
+          signerSigStatusEl.textContent = `signerSignature mismatch: recovered ${recovered}, expected ${message.signer}`;
+          signerSigStatusEl.style.color = "#c00";
+          signerSigValid = false;
+        }
+      } catch (err) {
+        signerSigStatusEl.textContent = err.message || String(err);
+        signerSigStatusEl.style.color = "#c00";
+        signerSigValid = false;
+      }
+    }
+
+    async function sendToApi(ignoreSigCheck = false) {
+      showError("");
+      apiStatusEl.textContent = "";
+      if (!sigEl.textContent && !ignoreSigCheck) {
+        showError("Please sign first to populate signature.");
+        return;
+      }
+      const signerSig = document.getElementById("signerSignature").value.trim();
+      if (!signerSig) {
+        showError("signerSignature is required.");
+        return;
+      }
+      await verifySignerSignature();
+      if (!signerSigValid) {
+        showError("signerSignature invalid. Please check the linked signer signature.");
+        return;
+      }
+      if (!document.getElementById("subaccountId").value) {
+        showError("subaccountId is required. Fetch or fill it first.");
+        return;
+      }
+      const signature = sigEl.textContent || lastSignature;
+      const payload = buildApiPayloadPreview(signature, lastTypedMessage);
+      const base = document.getElementById("apiBase").value.replace(/\/$/, "");
+      const url = `${base}/v1/linked-signer/link`;
+      try {
+        const res = await fetch(url, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", "accept": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        const text = await res.text();
+        if (res.ok) {
+          apiStatusEl.textContent = "Link success";
+          apiStatusEl.style.color = "#0a5";
+        } else {
+          apiStatusEl.textContent = `HTTP ${res.status}: ${text}`;
+          apiStatusEl.style.color = "#c00";
+        }
+      } catch (err) {
+        showError(err.message || err);
+        apiStatusEl.textContent = err.message || String(err);
+        apiStatusEl.style.color = "#c00";
+      }
+    }
+
+    document.getElementById("connect").addEventListener("click", connectWallet);
+    document.getElementById("sign").addEventListener("click", signTypedData);
+    document.getElementById("send").addEventListener("click", sendToApi);
+    document.getElementById("signerSignature").addEventListener("input", verifySignerSignature);
+    autoFillTime();
+
+    async function autoFetchSubaccountId() {
+      const sender = senderEl.value;
+      if (!sender) return;
+      const base = document.getElementById("apiBase").value.replace(/\/$/, "");
+      const url = `${base}/v1/subaccount?sender=${encodeURIComponent(sender)}`;
+      try {
+        const res = await fetch(url, { headers: { accept: "application/json" } });
+        const json = await res.json();
+        if (json && json.data && json.data.length > 0 && json.data[0].id) {
+          document.getElementById("subaccountId").value = json.data[0].id;
+        }
+      } catch (err) {
+        // silent
+      }
+    }
+  </script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,6 @@ x10-python-trading-starknet==0.0.10
 
 # Nado Protocol SDK
 git+https://github.com/your-quantguy/nado-python-sdk.git@7728e97dd030cf744f08afdc0637f7e63b7527e3
+
+# Ethereal exchange SDK
+ethereal-sdk==0.1.0b23


### PR DESCRIPTION
- 支持 Ethereal exchange （scalping 模式）
- 增加 Ethereal subaccount 生成和绑定脚本（html + python script）
  - 由于 Ethereal UI 没有提供授权子账户操作权限的功能，所以这里提供一个网页连接主账户，授权给子账户（仅交易权限）